### PR TITLE
Fix quarkus plugin config for dev mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,13 @@
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary
- include `quarkus-maven-plugin` build goal so that `mvn quarkus:dev` starts the server

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68618cea81ac8321bc1113cb3299e8ae