### PR TITLE
Fix Quarkus multipart dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-multipart</artifactId>
+            <artifactId>quarkus-resteasy-multipart</artifactId>
         </dependency>
         <dependency>
             <groupId>com.drewnoakes</groupId>


### PR DESCRIPTION
## Summary
- use correct Quarkus multipart extension

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_6861978b5d1c83218376f211bfa5916f