### PR TITLE
Fix Quarkus REST capability conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-multipart</artifactId>
+            <artifactId>quarkus-resteasy-reactive-multipart</artifactId>
         </dependency>
         <dependency>
             <groupId>com.drewnoakes</groupId>


### PR DESCRIPTION
## Summary
- use the RESTEasy Reactive multipart extension to avoid conflicts with the classic RESTEasy capability

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68619bac829083219857ed912cf8de21