### PR TITLE
Enable CORS for frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 *.class
 frontend/node_modules/
+frontend/package-lock.json

--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ To run the application in dev mode:
 ```bash
 mvn quarkus:dev
 ```
+
+The Angular dev server can be started from the `frontend` folder:
+
+```bash
+npx ng serve
+```
+
+The backend has CORS enabled for `http://localhost:4200` so the frontend can
+call the `/upload` endpoint during development.

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
+import { NgIf } from '@angular/common';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [],
+  imports: [NgIf],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 quarkus.http.port=8080
+
+# Enable CORS for Angular frontend
+quarkus.http.cors=true
+quarkus.http.cors.origins=http://localhost:4200
+quarkus.http.cors.headers=Content-Type
+quarkus.http.cors.methods=GET,POST,OPTIONS


### PR DESCRIPTION
## Summary
- allow Angular dev server to access the backend
- document running the Angular app
- ignore package-lock in git

## Testing
- `npx ng build`
- `mvn -q test` *(fails: unresolved dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861a71555b08321be04836abb6e6075